### PR TITLE
Msgilligan drop jdk6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,6 @@ matrix:
       jdk: oraclejdk7
     - os: linux
       jdk: openjdk7
-    - os: linux
-      jdk: openjdk6
 
 cache:
   directories:

--- a/README.adoc
+++ b/README.adoc
@@ -23,3 +23,10 @@ WARNING: This software is EXPERIMENTAL software. USE AT YOUR OWN RISK.
     ./gradlew test
 
 NOTE: `libbitcoinconsensus` must be available in the class path or as system library.
+
+== Platform Notes
+
+=== Mac OS X
+
+On Mac OS X you can put `libbitcoinconsensus.dylib` in `src/main/resources/`.
+


### PR DESCRIPTION
Remove `linux/openjdk6` from the Travis build matrix
